### PR TITLE
Don't uppercase API class headers

### DIFF
--- a/app/styles/guides.scss
+++ b/app/styles/guides.scss
@@ -37,6 +37,7 @@ body.guides, body.blog, body.api {
 
     &.api-header {
       padding-bottom: 0.5em;
+      text-transform: none;
     }
   }
 


### PR DESCRIPTION
The uppercase style can make it hard to tell how something needs to be cased when used. See http://emberjs.com/api/data/classes/DS.JSONAPIAdapter.html