### PR TITLE
Replace `view:application` with `component:scroll-wrapper`

### DIFF
--- a/app/components/scroll-wrapper.js
+++ b/app/components/scroll-wrapper.js
@@ -1,14 +1,10 @@
-import Ember from "ember";
+import Ember from 'ember';
 
 const { on } = Ember;
 
-export default Ember.View.extend({
+export default Ember.Component.extend({
   returnToTopLinkVisible: false,
-  actions: {
-    scrollToTop: function(){
-      window.scrollTo(0,0);
-    }
-  },
+
   observeScrollState: on('didInsertElement', function(){
     var _this = this;
     new window.Waypoint({

--- a/app/controllers/application.js
+++ b/app/controllers/application.js
@@ -11,6 +11,9 @@ export default Ember.Controller.extend({
   }),
 
   actions: {
+    scrollToTop: function(){
+      window.scrollTo(0,0);
+    },
     versionChanged(version){
       var parser = document.createElement('a');
       parser.href = window.location;

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -147,7 +147,10 @@ p {
   #back-to-top {
     padding-left: 13px;
     text-align: center;
-    display: none;
+    position: fixed;
+    top: 20px;
+    left: 0px;
+    display: block;
     @include transition(opacity 0.05s linear);
 
     @media screen and (max-width: 1200px) {

--- a/app/templates/application.hbs
+++ b/app/templates/application.hbs
@@ -1,3 +1,4 @@
+{{#scroll-wrapper as |returnToTopLinkVisible|}}
 <div id="header">
   <div id="wrapper">
     <a id="logo" href="/">&nbsp;</a>
@@ -86,9 +87,9 @@
         </ol>
       </li>
 
-      {{#if view.returnToTopLinkVisible}}
+      {{#if returnToTopLinkVisible}}
         <div id="back-to-top">
-          <a href="#" {{action "scrollToTop" target=view}}>⬆ Back to Top</a>
+          <a href="#" {{action "scrollToTop"}}>⬆ Back to Top</a>
         </div>
       {{/if}}
     </ol>
@@ -121,3 +122,4 @@
     </div>
   </div>
 </div>
+{{/scroll-wrapper}}

--- a/app/templates/components/scroll-wrapper.hbs
+++ b/app/templates/components/scroll-wrapper.hbs
@@ -1,0 +1,1 @@
+{{yield returnToTopLinkVisible}}


### PR DESCRIPTION
The ApplicatonView is the last location where `Ember.View` is extended.
Replacing this usage allows easy update to ember 2.x